### PR TITLE
Clean up properties

### DIFF
--- a/Tests/Feature/ElasticSearchAuditableTest.php
+++ b/Tests/Feature/ElasticSearchAuditableTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use Exception;
-use Illuminate\Support\Collection;
 use rajmundtoth0\AuditDriver\Tests\TestCase;
 
 /**
@@ -40,7 +39,6 @@ class ElasticSearchAuditableTest extends TestCase
             'name' => 'Test Doe',
         ]);
 
-        /** @var Collection<int, mixed> $auditLogs */
         $auditLogs = $user->auditLog;
 
         $this->assertSame($body, $auditLogs->toArray());

--- a/Tests/Feature/ElasticsearchClientExceptionsTest.php
+++ b/Tests/Feature/ElasticsearchClientExceptionsTest.php
@@ -25,6 +25,7 @@ class ElasticsearchClientExceptionsTest extends TestCase
         $this->expectException(AuditDriverConfigNotSetException::class);
         $this->expectExceptionMessage($message);
 
+        Config::set('audit.drivers.elastic.useBasicAuth', true);
         Config::set('audit.drivers.elastic.useCaCert', true);
         Config::set($key, null);
         resolve(ElasticsearchClient::class)

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -9,6 +9,7 @@ use Exception;
 use Http\Mock\Client as MockHttpClient;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\ServiceProvider;
 use Nyholm\Psr7\Response;
 use Orchestra\Testbench\TestCase as Orchestra;
 use OwenIt\Auditing\Models\Audit;
@@ -45,7 +46,7 @@ class TestCase extends Orchestra
         $this->loadMigrationsFrom(__DIR__.'/Migration');
     }
 
-    /** @return array<int, string> */
+    /** @return list<class-string<ServiceProvider>> */
     protected function getPackageProviders($app): array
     {
         return [
@@ -65,7 +66,6 @@ class TestCase extends Orchestra
             bodies: $bodies,
             shouldThrowException: $shouldThrowException,
         );
-        /** @var ElasticsearchAuditService $service*/
         $service = resolve(ElasticsearchAuditService::class)
             ->setClient($mockedElasticClient);
 
@@ -107,14 +107,6 @@ class TestCase extends Orchestra
             ->build();
     }
 
-    protected function getElasticsearchAuditService(): ElasticsearchAuditService
-    {
-        /** @var ElasticsearchAuditService */
-        $service = resolve(ElasticsearchAuditService::class);
-
-        return $service;
-    }
-
     /**
      * @param array<int|string, mixed> $body
      * @throws Exception
@@ -138,7 +130,6 @@ class TestCase extends Orchestra
 
     protected function getUser(): User
     {
-        /** @var User $user */
         $user = User::factory()->make();
 
         return $user;

--- a/src/Client/ElasticsearchClient.php
+++ b/src/Client/ElasticsearchClient.php
@@ -52,7 +52,7 @@ class ElasticsearchClient
      */
     public function setCaBundle(): void
     {
-        if (!config('audit.drivers.elastic.useCaCert', true)) {
+        if (!config('audit.drivers.elastic.useCaCert', false)) {
             return;
         }
         if (!$caCert = config('audit.drivers.elastic.certPath', false)) {
@@ -79,7 +79,7 @@ class ElasticsearchClient
      */
     public function setBasicAuth(): void
     {
-        if (!config('audit.drivers.elastic.useBasicAuth', true)) {
+        if (!config('audit.drivers.elastic.useBasicAuth', false)) {
             return;
         }
         if (!$userName = config('audit.drivers.elastic.userName', false)) {
@@ -106,7 +106,7 @@ class ElasticsearchClient
      */
     public function setHosts(): void
     {
-        $hosts = config('audit.drivers.elastic.hosts', []);
+        $hosts = config('audit.drivers.elastic.hosts', ['localhost']);
         if (!$hosts || !is_array($hosts)) {
             throw new AuditDriverConfigNotSetException(
                 message: 'Key audit.drivers.elastic.hosts is unset or has incorrect data type. Expected: array.',

--- a/src/Models/MappingModel.php
+++ b/src/Models/MappingModel.php
@@ -8,10 +8,11 @@ class MappingModel
 
     private const DEFAULT_DATE_FORMAT = 'yyyy-MM-dd HH:mm:ss';
 
-    public function __construct(
-        private string $dateFormat = '',
-    ) {
-        $dateFormatConfig = config(self::DATE_FORMAT_CONFIG_KEY, null);
+    private readonly string $dateFormat;
+
+    public function __construct()
+    {
+        $dateFormatConfig = config(self::DATE_FORMAT_CONFIG_KEY);
         $dateFormatConfig ??= self::DEFAULT_DATE_FORMAT;
         assert(is_string($dateFormatConfig));
         $this->dateFormat = $dateFormatConfig;
@@ -54,7 +55,7 @@ class MappingModel
         ];
     }
 
-    /** @return array<string, string> */
+    /** @return array{type:string, format:string} */
     private function getDateField(): array
     {
         return [

--- a/src/Traits/ElasticSearchAuditable.php
+++ b/src/Traits/ElasticSearchAuditable.php
@@ -13,7 +13,7 @@ use rajmundtoth0\AuditDriver\Services\ElasticsearchAuditService;
 trait ElasticSearchAuditable
 {
     /**
-     * @return Collection<int, mixed>
+     * @return Collection<array-key, mixed>
      *
      * @throws AuditDriverException
      * @throws ClientResponseException
@@ -23,7 +23,6 @@ trait ElasticSearchAuditable
      */
     public function elasticsearchAuditLog(int $page = 1, int $pageSize = 10, string $sort = 'desc'): Collection
     {
-        /** @var ElasticsearchAuditService */
         $elasticsearchAuditService = resolve(ElasticsearchAuditService::class);
         $result                    = $elasticsearchAuditService->searchAuditDocument(
             model: $this,


### PR DESCRIPTION
This allows Larastan to resolve the `ElasticsearchAuditService` class since the properties and there defaults are now provided in an order that allows it to be initiated with default values.

This also handles all PHPStan issues that where previously ignored.

Lastly this should also allow it to work with models where the primary key is not `id`.